### PR TITLE
tasks/configure: Don't backup configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,5 +6,4 @@
     owner: root
     group: root
     mode: 0640
-    backup: yes
   notify: Enable and restart zfs-snap-manager


### PR DESCRIPTION
It clutters /etc and the config is not *that* important