### PR TITLE
Fix dependency name for python2

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 - name: Install dependencies
   apt:
     name:
-      - python
+      - "{{ 'python' if ansible_distribution_release == 'stretch' or ansible_distribution_release == 'jessie' else 'python2' }}"
       - python-daemon
       - mbuffer
 


### PR DESCRIPTION
In old debian releases we need to install python
Since buster we need to install python2